### PR TITLE
Rename constant variable `tools` to `TOOLS`

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import random
 
-tools = ("rock", "paper", "scissors")
+TOOLS = ("rock", "paper", "scissors")
 
 
 def get_input() -> str:
@@ -14,11 +14,11 @@ def get_input() -> str:
 
 
 def check_input(move: str) -> bool:
-    return move in tools
+    return move in TOOLS
 
 
 def random_opponent_tool() -> str:
-    return random.choice(tools)
+    return random.choice(TOOLS)
 
 
 def check_winner(user_move: str, opponent_move: str) -> str:


### PR DESCRIPTION
The PEP 8 Style Guide for Python Code recommends that constant variables are written in all capital letters, so the `tools` variable is better suited as `TOOLS`.